### PR TITLE
Removed org-make-link and replaced it with concat

### DIFF
--- a/org-git-link.el
+++ b/org-git-link.el
@@ -182,7 +182,7 @@
   (let* ((gitdir (first (org-git-find-gitdir file)))
          (branchname (org-git-get-current-branch gitdir))
          (timestring (format-time-string "%Y-%m-%d" (current-time))))
-    (org-make-link "git:" file "::" (org-git-create-searchstring branchname timestring))))
+    (concat "git:" file "::" (org-git-create-searchstring branchname timestring))))
 
 (defun org-git-store-link ()
   "Store git link to current file."
@@ -198,7 +198,7 @@
 
 (defun org-git-insert-link-interactively (file searchstring &optional description)
   (interactive "FFile: \nsSearch string: \nsDescription: ")
-  (insert (org-make-link-string (org-make-link "git:" file "::" searchstring) description)))
+  (insert (org-make-link-string (concat "git:" file "::" searchstring) description)))
 
 ;; Calling git
 (defun org-git-show (gitdir object buffer)


### PR DESCRIPTION
org-make-link doesn't exist anymore. I've replaced it with concat https://lists.gnu.org/archive/html/emacs-orgmode/2012-08/msg00854.html